### PR TITLE
Tidy up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-devserver: init create_server host_known sleep setup_server setup_users
+all: init create_server host_known sleep setup_server setup_users
 
 .PHONY: \
+	all \
+	check \
 	create_server \
 	destroy_server \
-	devserver \
+	format \
 	host_known \
 	init \
-	linter \
 	setup_server \
 	setup_users \
 	sleep
@@ -14,6 +15,7 @@ devserver: init create_server host_known sleep setup_server setup_users
 clean:
 	rm --force --recursive src/.terraform
 	rm --force src/.terraform.lock.hcl
+	rm --force src/terraform.tfstate*
 
 create_server:
 	cd src && terraform apply -auto-approve -var "do_token=$${DO_PAT}" -var "pvt_key=$${HOME}/.ssh/id_rsa"
@@ -43,4 +45,3 @@ setup_users:
 sleep:
 	@echo "Waiting to avoid conflicts with APT. 😴 💤 😪"
 	sleep 100
-

--- a/src/droplet.tf
+++ b/src/droplet.tf
@@ -18,7 +18,7 @@ resource "digitalocean_droplet" "devserver" {
   }
 }
 
-resource "digitalocean_floating_ip_assignment" "foobar" {
+resource "digitalocean_floating_ip_assignment" "devip" {
   ip_address = "146.190.1.89"
   droplet_id = digitalocean_droplet.devserver.id
 }


### PR DESCRIPTION
🔀 🧹 Limpiamos el Makefile

## Descripción
- Actualizamos lista de phonies
- Borramos basura de terraform
- Cambiamos nombre del recurso

## Pendientes
- [ ] Agregar los permisos de _other_ a la carpeta `tmp/share`
- [ ] Refactorizar la instalación mediante `apt`
- [ ] Refactorizar la configuración de usuarios
- [ ] Revisar que estemos revisando el formato desde _actions_